### PR TITLE
Fix "yadm clone" from within a subdir of $YADM_WORK

### DIFF
--- a/yadm
+++ b/yadm
@@ -771,7 +771,7 @@ function clone() {
   configure_repo
 
   # then reset the index as the --no-checkout flag makes the index empty
-  "$GIT_PROGRAM" reset --quiet -- .
+  "$GIT_PROGRAM" reset --quiet -- "$YADM_WORK"
 
   if [ "$YADM_WORK" = "$HOME" ]; then
     debug "Determining if repo tracks private directories"


### PR DESCRIPTION
### What does this PR do?

When running "yadm clone" from a subdirectory of $YADM_WORK, e.g. from
$HOME/Music, YADM failed to populate its working context: The list of
files returned by the subsequent "git ls-files --deleted" (within the yadm script)
was empty then.

### Previous Behavior

When doing a "yadm clone" while the current working directory is a subdir
of $YADM_WORK, the working context in $YADM_WORK is not populated
with the files from the dotfile repository.

### New Behavior

Everything works fine even when being in a subdirectory of $YADM_WORK.

### Have [tests][1] been written for this change?

No, but all current tests passed.

### Have these commits been [signed with GnuPG][2]?

No
