### PR TITLE
Replace references to files.gpg with archive

### DIFF
--- a/_docs/110_faq.md
+++ b/_docs/110_faq.md
@@ -105,7 +105,7 @@ Of course. You only need `gpg`, `openssl`, `transcrypt` or `git-crypt` installed
 if you plan on using the encrypt/decrypt features. yadm will tell you if it is 
 missing a dependency for any command.
 
-### Should I `yadm add` my `.config/yadm/encrypt` file?
+### Should I `yadm add` my `~/.config/yadm/encrypt` file?
 
 Yes! This way your configuration for what files should be encrypted will follow
 you when you clone your repository.
@@ -113,9 +113,9 @@ you when you clone your repository.
 ### Should I `yadm add` encrypted files to repository?
 
 No, you should not. Instead, add the names (or wildcard patterns) of the files you want
-encrypted to `.config/yadm/encrypt`. Then, use the `yadm encrypt` command to encrypt the 
+encrypted to `~/.config/yadm/encrypt`. Then, use the `yadm encrypt` command to encrypt the 
 matched files which then adds them to `~/.local/share/yadm/archive`. Then, use 
-`cd ; yadm add .local/share/yadm/archive` to add this file to the yadm repository. 
+`yadm add ~/.local/share/yadm/archive` to add this file to the yadm repository. 
 This way, only encrypted versions of those files will be in the repository. After
 cloning or updating your repository, you can use `yadm decrypt` to extract the
 encrypted files from `~/.local/share/yadm/archive` into your working copy. See the
@@ -123,7 +123,7 @@ encrypted files from `~/.local/share/yadm/archive` into your working copy. See t
 
 ### I modified an encrypted file, but yadm doesn't show any modifications. Why?
 
-If you changed files which are matched by `.config/yadm/encrypt`, you must
+If you changed files which are matched by `~/.config/yadm/encrypt`, you must
 re-run `yadm encrypt` to generate a new version of `~/.local/share/yadm/archive`.
 Then `~/.local/share/yadm/archive` can be added to a new commit.
 

--- a/_docs/110_faq.md
+++ b/_docs/110_faq.md
@@ -94,16 +94,16 @@ what works best.
 
 ### I've created a bootstrap program. Should I add that to my repository?
 
+## Encryption
+
 Absolutely. That will allow your bootstrap program to be executed each time you
 clone your repository. Read [bootstrap](bootstrap) for more details.
 
-## Encryption
+### Can I use yadm without gpg, openssl, transcrypt or git-crypt?
 
-### Can I use yadm without gpg?
-
-Of course. You only need `gpg` installed if you plan on using the
-encrypt/decrypt features. yadm will tell you if it is missing a dependency
-for any command.
+Of course. You only need `gpg`, `openssl`, `transcrypt` or `git-crypt` installed 
+if you plan on using the encrypt/decrypt features. yadm will tell you if it is 
+missing a dependency for any command.
 
 ### Should I `yadm add` my `.config/yadm/encrypt` file?
 
@@ -112,19 +112,20 @@ you when you clone your repository.
 
 ### Should I `yadm add` encrypted files to repository?
 
-No, you should not. Files you want encrypted should be added to the file
-`.config/yadm/files.gpg` using the `yadm encrypt` command. Then
-`.config/yadm/files.gpg` should be added to the yadm repository. This way, only
-an encrypted collection of those files are put into the repository. After
-cloning or updating your repository, you can use `yadm decrypt` to extract those
-files from `.config/yadm/files.gpg`. See the
+No, you should not. Instead, add the names (or wildcard patterns) of the files you want
+encrypted to `.config/yadm/encrypt`. Then, use the `yadm encrypt` command to encrypt the 
+matched files which then adds them to `~/.local/share/yadm/archive`. Then, use 
+`cd ; yadm add .local/share/yadm/archive` to add this file to the yadm repository. 
+This way, only encrypted versions of those files will be in the repository. After
+cloning or updating your repository, you can use `yadm decrypt` to extract the
+encrypted files from `~/.local/share/yadm/archive` into your working copy. See the
 [encryption help](encryption) for more details.
 
 ### I modified an encrypted file, but yadm doesn't show any modifications. Why?
 
 If you changed files which are matched by `.config/yadm/encrypt`, you must
-re-run `yadm encrypt` to generate a new version of `.config/yadm/files.gpg`.
-Then `.config/yadm/files.gpg` can be added to a new commit.
+re-run `yadm encrypt` to generate a new version of `~/.local/share/yadm/archive`.
+Then `~/.local/share/yadm/archive` can be added to a new commit.
 
 ### Why do I get the error `Inappropriate ioctl for device` when encrypting.
 

--- a/_docs/110_faq.md
+++ b/_docs/110_faq.md
@@ -94,10 +94,10 @@ what works best.
 
 ### I've created a bootstrap program. Should I add that to my repository?
 
-## Encryption
-
 Absolutely. That will allow your bootstrap program to be executed each time you
 clone your repository. Read [bootstrap](bootstrap) for more details.
+
+## Encryption
 
 ### Can I use yadm without gpg, openssl, transcrypt or git-crypt?
 


### PR DESCRIPTION
### What does this PR do?

 Replaces references to `files.gpg` with `~/.local/share/yadm/archive`. Other encryption related doc fixes.
 
Branched off dev-pages instead of gh-pages. #336 was branched of gh-pages by accident.

### What issues does this PR fix or reference?

Fixes #334. Replaces #336.

### Previous Behavior

FAQ referred to obsolete file files.gpg.

### New Behavior

FAQ refers to current ~/.local/share/yadm/archive file.

### Have [tests][1] been written for this change?

No. Doc changes only.

### Have these commits been [signed with GnuPG][2]?

Yes.

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
