### PR TITLE
Call bootstrap scripts with a tty.

### DIFF
--- a/contrib/bootstrap/bootstrap-in-dir
+++ b/contrib/bootstrap/bootstrap-in-dir
@@ -14,7 +14,10 @@ if [[ ! -d "$BOOTSTRAP_D" ]]; then
     exit 1
 fi
 
-find -L "$BOOTSTRAP_D" -type f | sort | while IFS= read -r bootstrap; do
+IFS=$'\n'
+bootstraps=( $(find -L "$BOOTSTRAP_D" -type f | sort) )
+unset IFS
+for bootstrap in "${bootstraps[@]}"; do
     if [[ -x "$bootstrap" && ! "$bootstrap" =~ "##" && ! "$bootstrap" =~ "~$" ]]; then
         if ! "$bootstrap"; then
             echo "Error: bootstrap '$bootstrap' failed" >&2

--- a/contrib/bootstrap/bootstrap-in-dir
+++ b/contrib/bootstrap/bootstrap-in-dir
@@ -14,9 +14,7 @@ if [[ ! -d "$BOOTSTRAP_D" ]]; then
     exit 1
 fi
 
-IFS=$'\n'
-bootstraps=( $(find -L "$BOOTSTRAP_D" -type f | sort) )
-unset IFS
+mapfile -t bootstraps < <(find -L "$BOOTSTRAP_D" -type f | sort)
 for bootstrap in "${bootstraps[@]}"; do
     if [[ -x "$bootstrap" && ! "$bootstrap" =~ "##" && ! "$bootstrap" =~ "~$" ]]; then
         if ! "$bootstrap"; then


### PR DESCRIPTION
### What does this PR do?

Changes the contributed bootstrap-in-dir script so that it passes the tty through to the individual bootstrap scripts.

### What issues does this PR fix or reference?

#344 

### Previous Behavior

stdin for the individual scripts was the pipe from the find command.

### New Behavior

stdin for the individual scripts is the same as it is for the bootstrap-in-dir script (typically a tty)

### Have [tests][1] been written for this change?

no

### Have these commits been [signed with GnuPG][2]?

no

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
