### PR TITLE
Fixed issue #455-lowercasing checks on both sides

### DIFF
--- a/yadm
+++ b/yadm
@@ -204,7 +204,7 @@ function score_file() {
         return
       fi
     elif [[ "$label" =~ ^(d|distro)$ ]]; then
-      value=${value,,}
+      value=$(echo $value | tr '[:upper:]' '[:lower:]')
       if [ "${value/\ /_}" = "${local_distro/\ /_}" ]; then
         score=$((score + 4))
       else
@@ -212,7 +212,7 @@ function score_file() {
         return
       fi
     elif [[ "$label" =~ ^(f|distro_family)$ ]]; then
-      value=${value,,}
+      value=$(echo $value | tr '[:upper:]' '[:lower:]')
       if [ "${value/\ /_}" = "${local_distro_family/\ /_}" ]; then
         score=$((score + 8))
       else
@@ -1524,7 +1524,7 @@ function query_distro() {
       fi
     done < "$OS_RELEASE"
   fi
-  echo "${distro,,}"
+  echo "$distro" | tr '[:upper:]' '[:lower:]'
 }
 
 function query_distro_family() {
@@ -1538,7 +1538,7 @@ function query_distro_family() {
       fi
     done < "$OS_RELEASE"
   fi
-  echo "${family,,}"
+  echo "$family" | tr '[:upper:]' '[:lower:]'
 }
 
 function process_global_args() {

--- a/yadm
+++ b/yadm
@@ -204,6 +204,7 @@ function score_file() {
         return
       fi
     elif [[ "$label" =~ ^(d|distro)$ ]]; then
+      value=${value,,}
       if [ "${value/\ /_}" = "${local_distro/\ /_}" ]; then
         score=$((score + 4))
       else
@@ -211,6 +212,7 @@ function score_file() {
         return
       fi
     elif [[ "$label" =~ ^(f|distro_family)$ ]]; then
+      value=${value,,}
       if [ "${value/\ /_}" = "${local_distro_family/\ /_}" ]; then
         score=$((score + 8))
       else
@@ -1522,7 +1524,7 @@ function query_distro() {
       fi
     done < "$OS_RELEASE"
   fi
-  echo "$distro"
+  echo "${distro,,}"
 }
 
 function query_distro_family() {
@@ -1536,7 +1538,7 @@ function query_distro_family() {
       fi
     done < "$OS_RELEASE"
   fi
-  echo "$family"
+  echo "${family,,}"
 }
 
 function process_global_args() {

--- a/yadm
+++ b/yadm
@@ -204,7 +204,7 @@ function score_file() {
         return
       fi
     elif [[ "$label" =~ ^(d|distro)$ ]]; then
-      value=$(echo $value | tr '[:upper:]' '[:lower:]')
+      value="$(echo $value | tr '[:upper:]' '[:lower:]')"
       if [ "${value/\ /_}" = "${local_distro/\ /_}" ]; then
         score=$((score + 4))
       else
@@ -212,7 +212,7 @@ function score_file() {
         return
       fi
     elif [[ "$label" =~ ^(f|distro_family)$ ]]; then
-      value=$(echo $value | tr '[:upper:]' '[:lower:]')
+      value="$(echo $value | tr '[:upper:]' '[:lower:]')"
       if [ "${value/\ /_}" = "${local_distro_family/\ /_}" ]; then
         score=$((score + 8))
       else

--- a/yadm
+++ b/yadm
@@ -204,7 +204,6 @@ function score_file() {
         return
       fi
     elif [[ "$label" =~ ^(d|distro)$ ]]; then
-      #value=$(echo "$value" | "${AWK_PROGRAM[0]}" '{print tolower($0)}') # FIXME Remove
       value=$("${AWK_PROGRAM[0]}" '{print tolower($0)}' <<<"$value")
       if [ "${value/\ /_}" = "${local_distro/\ /_}" ]; then
         score=$((score + 4))
@@ -213,7 +212,6 @@ function score_file() {
         return
       fi
     elif [[ "$label" =~ ^(f|distro_family)$ ]]; then
-      #value=$(echo "$value" | "${AWK_PROGRAM[0]}" '{print tolower($0)}') # FIXME Remove
       value=$("${AWK_PROGRAM[0]}" '{print tolower($0)}' <<<"$value")
       if [ "${value/\ /_}" = "${local_distro_family/\ /_}" ]; then
         score=$((score + 8))
@@ -1526,7 +1524,6 @@ function query_distro() {
       fi
     done < "$OS_RELEASE"
   fi
-  #echo "$distro" | "${AWK_PROGRAM[0]}" '{print tolower($0)}' ## FIXME Remove
   "${AWK_PROGRAM[0]}" '{print tolower($0)}' <<<"$distro"
 }
 
@@ -1544,7 +1541,6 @@ function query_distro_family() {
       fi
     done < "$OS_RELEASE"
   fi
-  #echo "$distro" | "${AWK_PROGRAM[0]}" '{print tolower($0)}' ##  FIXME Remove
   "${AWK_PROGRAM[0]}" '{print tolower($0)}' <<<"$distro"
 }
 

--- a/yadm
+++ b/yadm
@@ -204,7 +204,8 @@ function score_file() {
         return
       fi
     elif [[ "$label" =~ ^(d|distro)$ ]]; then
-      value=$(echo "$value" | "${AWK_PROGRAM[0]}" '{print tolower($0)}')
+      #value=$(echo "$value" | "${AWK_PROGRAM[0]}" '{print tolower($0)}') # FIXME Remove
+      value=$("${AWK_PROGRAM[0]}" '{print tolower($0)}' <<<"$value")
       if [ "${value/\ /_}" = "${local_distro/\ /_}" ]; then
         score=$((score + 4))
       else
@@ -212,7 +213,8 @@ function score_file() {
         return
       fi
     elif [[ "$label" =~ ^(f|distro_family)$ ]]; then
-      value=$(echo "$value" | "${AWK_PROGRAM[0]}" '{print tolower($0)}')
+      #value=$(echo "$value" | "${AWK_PROGRAM[0]}" '{print tolower($0)}') # FIXME Remove
+      value=$("${AWK_PROGRAM[0]}" '{print tolower($0)}' <<<"$value")
       if [ "${value/\ /_}" = "${local_distro_family/\ /_}" ]; then
         score=$((score + 8))
       else
@@ -1524,7 +1526,8 @@ function query_distro() {
       fi
     done < "$OS_RELEASE"
   fi
-  echo "$distro" | "${AWK_PROGRAM[0]}" '{print tolower($0)}'
+  #echo "$distro" | "${AWK_PROGRAM[0]}" '{print tolower($0)}' ## FIXME Remove
+  "${AWK_PROGRAM[0]}" '{print tolower($0)}' <<<"$distro"
 }
 
 function query_distro_family() {
@@ -1541,7 +1544,8 @@ function query_distro_family() {
       fi
     done < "$OS_RELEASE"
   fi
-  echo "$distro" | "${AWK_PROGRAM[0]}" '{print tolower($0)}'
+  #echo "$distro" | "${AWK_PROGRAM[0]}" '{print tolower($0)}' ##  FIXME Remove
+  "${AWK_PROGRAM[0]}" '{print tolower($0)}' <<<"$distro"
 }
 
 function process_global_args() {

--- a/yadm
+++ b/yadm
@@ -204,7 +204,7 @@ function score_file() {
         return
       fi
     elif [[ "$label" =~ ^(d|distro)$ ]]; then
-      value="$(echo $value | tr '[:upper:]' '[:lower:]')"
+      value=$(echo "$value" | "${AWK_PROGRAM[0]}" '{print tolower($0)}')
       if [ "${value/\ /_}" = "${local_distro/\ /_}" ]; then
         score=$((score + 4))
       else
@@ -212,7 +212,7 @@ function score_file() {
         return
       fi
     elif [[ "$label" =~ ^(f|distro_family)$ ]]; then
-      value="$(echo $value | tr '[:upper:]' '[:lower:]')"
+      value=$(echo "$value" | "${AWK_PROGRAM[0]}" '{print tolower($0)}')
       if [ "${value/\ /_}" = "${local_distro_family/\ /_}" ]; then
         score=$((score + 8))
       else
@@ -1524,7 +1524,7 @@ function query_distro() {
       fi
     done < "$OS_RELEASE"
   fi
-  echo "$distro" | tr '[:upper:]' '[:lower:]'
+  echo "$distro" | "${AWK_PROGRAM[0]}" '{print tolower($0)}'
 }
 
 function query_distro_family() {
@@ -1535,10 +1535,13 @@ function query_distro_family() {
         family="${line#ID_LIKE=}"
         family="${family//\"}"
         break
+      elif [[ -z "$family" && "$line" = ID=* ]]; then
+        family="${line#ID=}"
+        family="${family//\"}"
       fi
     done < "$OS_RELEASE"
   fi
-  echo "$family" | tr '[:upper:]' '[:lower:]'
+  echo "$distro" | "${AWK_PROGRAM[0]}" '{print tolower($0)}'
 }
 
 function process_global_args() {


### PR DESCRIPTION
### What does this PR do?

It allows differences between lsb_release and os-release to continue to work by simply comparing values of key in filename and value from detection in lowercase, gracefully allowing prior existing cases to work as they should.

### What issues does this PR fix or reference?

#455
#430 

### Previous Behavior

Comparison was using lsb_release, which formalized output -OR- went to os-release which ID is always lowercase per spec, causing differences in results based on which method was used for detection.
It also accounts for distro_family that is using ID_LIKE, or if not available would revert to ID for base distros.

### New Behavior

Comparison lowercases the value provided from the alternative processor, and from the output of the distro detection, to provide consistent matching behavior that works, now and for all previous use-cases.

### Have [tests][1] been written for this change?

No

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
