### PR TITLE
Add more robust work directory parsing

### DIFF
--- a/yadm
+++ b/yadm
@@ -1679,6 +1679,25 @@ EOF
 
 }
 
+function parse_work_dir() {
+  WORKTREE_VAL=$($GIT_PROGRAM -C "$YADM_REPO" config core.worktree 2>/dev/null)
+  
+  # core.worktree value is empty, This means we are working with a root git repository not configured for yadm
+  if [[ -z $WORKTREE_VAL ]]; then
+    IS_REPO=$($GIT_PROGRAM -C "$YADM_REPO" rev-parse --is-inside-work-tree > /dev/null 2>&1)
+    if [[ -d "$YADM_REPO" &&  -n "$IS_REPO"  ]]; then
+      echo "$YADM_REPO"
+    else
+      echo "$HOME"
+    fi
+  elif [[ $WORKTREE_VAL == /* ]]; then # core.worktree is an absolute path
+    echo "$WORKTREE_VAL"
+  else # core.worktree is relative path (submodule not configured for yadm), combine with YADM_REPO to find absolute path
+    COMBINED_PATH=$(realpath "$YADM_REPO/$WORKTREE_VAL")
+    readlink -e "$COMBINED_PATH" || error_out "Unable to parse work directory"
+  fi
+}
+
 function configure_paths() {
 
   # change paths to be relative to YADM_DIR
@@ -1716,7 +1735,7 @@ function configure_paths() {
   # obtain YADM_WORK from repo if it exists
   if [ -d "$GIT_DIR" ]; then
     local work
-    work=$(unix_path "$("$GIT_PROGRAM" config core.worktree)")
+    work=$(parse_work_dir)
     [ -n "$work" ] && YADM_WORK="$work"
   fi
 


### PR DESCRIPTION
### What does this PR do?

This PR removed the requirement for the user to provide the -w and  the associated file path when dealing with git submodules. As described in the issue I had created (#501) where git operations were not working correctly even though the `--yadm-data`, `--yadm-dir`, `--yadm-repo` arguments were being supplied to yadm, I see this as a way in which yadm can take a step towards `Staying out of the way and letting Git do what it’s good at` by relying less on the manual setting of the `core.worktree` git config value and requiring fewer configuration values past the three arguments I mentioned above.

There are 3 situations which this new function handles:

1. **When `core.worktree` is not filled:** This means that the user is working with or initializing a top level git repository in yadm which has not been initialized through yadm before. This is the first branch of the if statement, where I am either returning `$YADM_REPO` defaulting to `$HOME` if `$YADM_REPO` is not valid.
2. **When `core.worktree` is an absolute path:** This means that we are dealing with a top level git repository or a git submodule which has been initialized through yadm. This branch will handle the situations dealing with all correctly configured yadm repositories.
3. **When `core.worktree` is a relative path:** This means that we are dealing with a submodule which has not been initialized through yadm. Git, when dealing with submodules naturally, will populate the `core.worktree` config with a relative path that points to the submodule it is managing in relation to the top level repositories location in which it stores the submodules git config.

An example for situation 3 would be if I had a top level repository located at `~/test` with a submodule in a directory at `~/test/.secrets`. If only configured through git, the `$YADM_REPO` value that I would supply would be `~/test/.git/modules/.secrets` and the `core.worktree` value written by git would be `../../../.secrets`. Given those examples we could combine the `$YADM_REPO` value with the `core.worktree` output to get an absolute path to the actual location of the directory we are working with.

### What issues does this PR fix or reference?

#501 

### Previous Behavior

Previously yadm would require the user to supply the `-w <path to workdir>` argument with the `yadm init` command when working with submodules, otherwise git commands would not function. This still works with that method of initialization.

### New Behavior

The new behavior would allow for the user to just initialize the repo through git and not yadm. Either method would work now.

### Have [tests][1] been written for this change?

No, but I can add them if requested.

### Have these commits been [signed with GnuPG][2]?

Yes.

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/yadm-dev/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/yadm-dev/yadm/blob/master/.github/CONTRIBUTING.md
