### PR TITLE
Make "yadm clone --recursive" work as expected.

### DIFF
--- a/yadm
+++ b/yadm
@@ -795,6 +795,7 @@ function clone() {
   DO_BOOTSTRAP=1
   local -a args
   local -i do_checkout=1
+  local -i do_submodules=0
   while [[ $# -gt 0 ]] ; do
     case "$1" in
       --bootstrap) # force bootstrap, without prompt
@@ -809,7 +810,10 @@ function clone() {
       -n|--no-checkout)
         do_checkout=0
       ;;
-      --bare|--mirror|--recurse-submodules*|--recursive|--separate-git-dir=*)
+      --recursive)
+        do_submodules=1
+      ;;
+      --bare|--mirror|--recurse-submodules*|--separate-git-dir=*)
         # ignore arguments without separate parameter
       ;;
       --separate-git-dir)
@@ -875,6 +879,10 @@ function clone() {
       "$GIT_PROGRAM" ls-files --deleted | while IFS= read -r file; do
           "$GIT_PROGRAM" checkout -- ":/$file"
       done
+
+      if [[ $do_submodules -ne 0 ]]; then
+          "$GIT_PROGRAM" submodule update --init --recursive
+      fi
 
       if [ -n "$("$GIT_PROGRAM" ls-files --modified)" ]; then
         local msg


### PR DESCRIPTION
The title says it all: If a dotfile repo has submodules, adding the --recursive switch to "yadm clone" causes all its submodules to be cloned as well. Thus, a subsequent "yadm submodule update --init --recursive" is no longer needed. 
