### PR TITLE
Fix testing with WSL.

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -93,7 +93,13 @@ def tst_distro_family(runner):
 @pytest.fixture(scope="session")
 def tst_sys():
     """Test session's uname value"""
-    return platform.system()
+    system = platform.system()
+    if system == "Linux":
+        # Additional check for WSL
+        with open("/proc/version", "r", encoding="utf-8") as f:
+            if "icrosoft" in f.read():
+                return "WSL"
+    return system
 
 
 @pytest.fixture(scope="session")

--- a/test/test_unit_set_os.py
+++ b/test/test_unit_set_os.py
@@ -24,8 +24,7 @@ def test_set_operating_system(runner, paths, tst_sys, proc_value, expected_os):
     # Normally /proc/version (set in PROC_VERSION) is inspected to identify
     # WSL. During testing, we will override that value.
     proc_version = paths.root.join("proc_version")
-    if proc_value != "missing":
-        proc_version.write(proc_value)
+    proc_version.write(proc_value)
     script = f"""
         YADM_TEST=1 source {paths.pgm}
         PROC_VERSION={proc_version}
@@ -36,5 +35,8 @@ def test_set_operating_system(runner, paths, tst_sys, proc_value, expected_os):
     assert run.success
     assert run.err == ""
     if expected_os == "uname":
-        expected_os = tst_sys
+        if tst_sys != "WSL":
+            expected_os = tst_sys
+        else:
+            expected_os = "Linux"
     assert run.out.rstrip() == expected_os


### PR DESCRIPTION
"make test" does not work on WSL, despite the fact that the test suite runs in a Docker container. This patch fixes that.

Furthermore, I just saw today that the test suite seems to be executed on Darwin and Ubuntu runners. As I usually use GitLab, I'm not that familiar with GitHub's CI/CD: Does is also offer WSL runners? GitHub _is_ a Microsoft product after all :-). If so, it would be good to add a WSL runner as well.