### PR TITLE
Make "yadm clone --recursive" work as expected.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,6 +119,7 @@ jobs:
         run: |
           git config --global user.email test@yadm.io
           git config --global user.name "Yadm Test"
+          git config --global protocol.file.allow always
 
           dos2unix yadm.1 .github/workflows/*.yml test/pinentry-mock
           chmod +x test/pinentry-mock

--- a/test/test_clone.py
+++ b/test/test_clone.py
@@ -108,6 +108,39 @@ def test_clone(runner, paths, yadm_cmd, repo_config, ds1, good_remote, repo_exis
             assert old_repo.exists()
 
 
+@pytest.mark.usefixtures("remote_with_submodules")
+@pytest.mark.parametrize("action", ["recursive", "recurse", "specific"])
+def test_clone_submodules(runner, paths, yadm_cmd, repo_config, action):
+    """Test clone operation with submodules"""
+
+    # clear out the work path
+    paths.work.remove()
+    paths.work.mkdir()
+
+    env = {
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "protocol.file.allow",
+        "GIT_CONFIG_VALUE_0": "always",
+    }
+
+    args = ["clone", "-w", paths.work]
+    if action == "recursive":
+        args += ["--recursive"]
+    elif action == "recurse":
+        args += ["--recurse-submodules"]
+    elif action == "specific":
+        args += ["--recurse-submodules=a", "--recurse-submodules=d1/c"]
+    args += [f"file://{paths.remote}"]
+    run = runner(command=yadm_cmd(*args), env=env)
+    assert successful_clone(run, paths, repo_config)
+
+    for path in ("a", "b", "d1/c"):
+        if action != "specific" or path != "b":
+            assert paths.work.join(path).join(".git").exists()
+        else:
+            assert not paths.work.join(path).join(".git").exists()
+
+
 @pytest.mark.usefixtures("remote")
 @pytest.mark.parametrize(
     "bs_exists, bs_param, answer",
@@ -305,16 +338,38 @@ def remote(paths, ds1_repo_copy):
     """Function scoped remote (based on ds1)"""
     # pylint: disable=unused-argument
     # This is ignored because
-    # @pytest.mark.usefixtures('ds1_remote_copy')
+    # @pytest.mark.usefixtures('ds1_repo_copy')
     # cannot be applied to another fixture.
     paths.remote.remove()
     paths.repo.move(paths.remote)
 
 
-def test_no_repo(
-    runner,
-    yadm_cmd,
-):
+@pytest.fixture()
+def remote_with_submodules(tmpdir_factory, runner, paths, remote, ds1_work_copy):
+    """Function scoped remote with submodules (based on ds1)"""
+    # pylint: disable=unused-argument
+    # This is ignored because
+    # @pytest.mark.usefixtures('remote', 'ds1_work_copy')
+    # cannot be applied to another fixture.
+    submodule = tmpdir_factory.mktemp("submodule")
+    paths.remote.copy(submodule)
+
+    env = os.environ.copy()
+    env["GIT_DIR"] = str(paths.remote)
+
+    for path in ("a", "b", "d1/c"):
+        run = runner(
+            ["git", "-C", paths.work, "-c", "protocol.file.allow=always", "submodule", "add", submodule, path],
+            env=env,
+            report=False,
+        )
+        assert run.success
+
+    run = runner(["git", "-C", paths.work, "commit", "-m", '"Add submodules"'], env=env, report=False)
+    assert run.success
+
+
+def test_no_repo(runner, yadm_cmd):
     """Test cloning without specifying a repo"""
     run = runner(command=yadm_cmd("clone", "-f"))
     assert run.failure

--- a/yadm
+++ b/yadm
@@ -754,7 +754,7 @@ function clone() {
   DO_BOOTSTRAP=1
   local -a args
   local -i do_checkout=1
-  local -i do_submodules=0
+  local -a submodules
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --bootstrap) # force bootstrap, without prompt
@@ -769,10 +769,13 @@ function clone() {
       -n | --no-checkout)
         do_checkout=0
         ;;
-      --recursive)
-        do_submodules=1
+      --recursive | --recurse-submodules)
+        submodules+=(":/")
         ;;
-      --bare | --mirror | --recurse-submodules* | --separate-git-dir=*)
+      --recurse-submodules=*)
+        submodules+=(":/${1#*=}")
+        ;;
+      --bare | --mirror | --separate-git-dir=*)
         # ignore arguments without separate parameter
         ;;
       --separate-git-dir)
@@ -839,8 +842,8 @@ function clone() {
       "$GIT_PROGRAM" checkout -- ":/$file"
     done
 
-    if [[ $do_submodules -ne 0 ]]; then
-      "$GIT_PROGRAM" submodule update --init --recursive
+    if [ ${#submodules[@]} -gt 0 ]; then
+      "$GIT_PROGRAM" submodule update --init --recursive -- "${submodules[@]}"
     fi
 
     if [ -n "$("$GIT_PROGRAM" ls-files --modified)" ]; then

--- a/yadm
+++ b/yadm
@@ -754,6 +754,7 @@ function clone() {
   DO_BOOTSTRAP=1
   local -a args
   local -i do_checkout=1
+  local -i do_submodules=0
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --bootstrap) # force bootstrap, without prompt
@@ -768,7 +769,10 @@ function clone() {
       -n | --no-checkout)
         do_checkout=0
         ;;
-      --bare | --mirror | --recurse-submodules* | --recursive | --separate-git-dir=*)
+      --recursive)
+        do_submodules=1
+        ;;
+      --bare | --mirror | --recurse-submodules* | --separate-git-dir=*)
         # ignore arguments without separate parameter
         ;;
       --separate-git-dir)
@@ -834,6 +838,10 @@ function clone() {
     "$GIT_PROGRAM" ls-files --deleted | while IFS= read -r file; do
       "$GIT_PROGRAM" checkout -- ":/$file"
     done
+
+    if [[ $do_submodules -ne 0 ]]; then
+      "$GIT_PROGRAM" submodule update --init --recursive
+    fi
 
     if [ -n "$("$GIT_PROGRAM" ls-files --modified)" ]; then
       local msg


### PR DESCRIPTION
The --recursive switch was ignored when YADM clones a dotfile repository. This commit causes "yadm clone --recursive" to also clone submodules in one go, similar to what GIT does when given the --recursive switch.
