### PR TITLE
[feature] Added support for negative alt condition

### DIFF
--- a/test/test_unit_score_file.py
+++ b/test/test_unit_score_file.py
@@ -321,3 +321,24 @@ def test_underscores_and_upper_case_in_distro_and_family(runner, yadm):
     assert run.success
     assert run.err == ""
     assert run.out == expected
+
+def test_negative_class_condition(runner, yadm):
+    """Test negative class condition: returns 0 when matching and proper score when not matching."""
+    script = f"""
+        YADM_TEST=1 source {yadm}
+        score=0
+        local_class="testclass"
+        local_classes=("testclass")
+        # Negative condition with matching value should yield delta -1 and zero the score.
+        score_file "filename##!class.testclass" "dest"
+        echo "score: $score"
+        # Negative condition with non-matching value should yield delta 16.
+        score=0
+        score_file "filename##!class.badclass" "dest"
+        echo "score2: $score"
+    """
+    run = runner(command=["bash"], inp=script)
+    assert run.success
+    output = run.out.strip().splitlines()
+    assert output[0] == "score: 0"
+    assert output[1] == "score2: 1016"

--- a/test/test_unit_score_file.py
+++ b/test/test_unit_score_file.py
@@ -329,16 +329,19 @@ def test_negative_class_condition(runner, yadm):
         score=0
         local_class="testclass"
         local_classes=("testclass")
-        # Negative condition with matching value should yield delta -1 and zero the score.
-        score_file "filename##!class.testclass" "dest"
+        
+        # 0
+        score_file "filename##~class.testclass" "dest"
         echo "score: $score"
-        # Negative condition with non-matching value should yield delta 16.
+
+        # 1000 + 16
         score=0
-        score_file "filename##!class.badclass" "dest"
+        score_file "filename##~class.badclass" "dest"
         echo "score2: $score"
-        # Check class shorthand (c) as well.
+
+        # 0
         score=0
-        score_file "filename##!c.testclass" "dest"
+        score_file "filename##~c.badclass" "dest"
         echo "score3: $score"
     """
     run = runner(command=["bash"], inp=script)
@@ -346,7 +349,7 @@ def test_negative_class_condition(runner, yadm):
     output = run.out.strip().splitlines()
     assert output[0] == "score: 0"
     assert output[1] == "score2: 1016"
-    assert output[2] == "score3: 0"
+    assert output[2] == "score3: 1016"
 
 def test_negative_combined_conditions(runner, yadm):
     """Test negative conditions for multiple alt types: returns 0 when matching and proper score when not matching."""
@@ -359,7 +362,7 @@ def test_negative_combined_conditions(runner, yadm):
 
         # 0 + 0 = 0
         score=0
-        score_file "filename##!class.testclass,!distro.testdistro" "dest"
+        score_file "filename##~class.testclass,~distro.testdistro" "dest"
         echo "score: $score"
 
         # 1000 * 2 + 16 + 4 = 2020
@@ -369,17 +372,17 @@ def test_negative_combined_conditions(runner, yadm):
 
         # 0 (negated class condition)
         score=0
-        score_file "filename##!class.badclass,!distro.testdistro" "dest"
+        score_file "filename##~class.badclass,~distro.testdistro" "dest"
         echo "score3: $score"
 
         # 1000 + 16 + 1000 + 4 = 2020
         score=0
-        score_file "filename##class.testclass,!distro.baddistro" "dest"
+        score_file "filename##class.testclass,~distro.baddistro" "dest"
         echo "score4: $score"
 
         # 1000 + 16 + 1000 + 16 = 2032
         score=0
-        score_file "filename##class.testclass,!class.badclass" "dest"
+        score_file "filename##class.testclass,~class.badclass" "dest"
         echo "score5: $score"
     """
     run = runner(command=["bash"], inp=script)

--- a/test/test_unit_score_file.py
+++ b/test/test_unit_score_file.py
@@ -326,20 +326,20 @@ def test_negative_class_condition(runner, yadm):
     """Test negative class condition: returns 0 when matching and proper score when not matching."""
     script = f"""
         YADM_TEST=1 source {yadm}
-        score=0
         local_class="testclass"
         local_classes=("testclass")
         
         # 0
+        score=0
         score_file "filename##~class.testclass" "dest"
         echo "score: $score"
 
-        # 1000 + 16
+        # 16
         score=0
         score_file "filename##~class.badclass" "dest"
         echo "score2: $score"
 
-        # 0
+        # 16
         score=0
         score_file "filename##~c.badclass" "dest"
         echo "score3: $score"
@@ -348,24 +348,23 @@ def test_negative_class_condition(runner, yadm):
     assert run.success
     output = run.out.strip().splitlines()
     assert output[0] == "score: 0"
-    assert output[1] == "score2: 1016"
-    assert output[2] == "score3: 1016"
+    assert output[1] == "score2: 16"
+    assert output[2] == "score3: 16"
 
 def test_negative_combined_conditions(runner, yadm):
     """Test negative conditions for multiple alt types: returns 0 when matching and proper score when not matching."""
     script = f"""
         YADM_TEST=1 source {yadm}
-        score=0
         local_class="testclass"
         local_classes=("testclass")
         local_distro="testdistro"
 
-        # 0 + 0 = 0
+        # (0) + (0) = 0
         score=0
         score_file "filename##~class.testclass,~distro.testdistro" "dest"
         echo "score: $score"
 
-        # 1000 * 2 + 16 + 4 = 2020
+        # (1000 + 16) + (1000 + 4) = 2020
         score=0
         score_file "filename##class.testclass,distro.testdistro" "dest"
         echo "score2: $score"
@@ -375,12 +374,12 @@ def test_negative_combined_conditions(runner, yadm):
         score_file "filename##~class.badclass,~distro.testdistro" "dest"
         echo "score3: $score"
 
-        # 1000 + 16 + 1000 + 4 = 2020
+        # (1000 + 16) + (4) = 1020
         score=0
         score_file "filename##class.testclass,~distro.baddistro" "dest"
         echo "score4: $score"
 
-        # 1000 + 16 + 1000 + 16 = 2032
+        # (1000 + 16) + (16) = 1032
         score=0
         score_file "filename##class.testclass,~class.badclass" "dest"
         echo "score5: $score"
@@ -391,5 +390,5 @@ def test_negative_combined_conditions(runner, yadm):
     assert output[0] == "score: 0"
     assert output[1] == "score2: 2020"
     assert output[2] == "score3: 0"
-    assert output[3] == "score4: 2020"
-    assert output[4] == "score5: 2032"
+    assert output[3] == "score4: 1020"
+    assert output[4] == "score5: 1032"

--- a/yadm
+++ b/yadm
@@ -242,7 +242,8 @@ function score_file() {
       score=0
       return
     fi
-    score=$((score + 1000 + delta))
+    (( negate )) || delta=$((delta + 1000))
+    score=$((score + delta))
   done
 
   record_score "$score" "$target" "$source" "$template_processor"

--- a/yadm
+++ b/yadm
@@ -179,9 +179,9 @@ function score_file() {
     local value=${field#*.}
     [ "$field" = "$label" ] && value="" # when .value is omitted
 
-    # Check for negative condition prefix (e.g., "!<label>")
+    # Check for negative condition prefix (e.g., "~<label>")
     local negate=0
-    if [[ "$label" == !* ]]; then
+    if [[ "$label" == ~* ]]; then
       negate=1
       label="${label:1}"
     fi
@@ -193,55 +193,28 @@ function score_file() {
         delta=0
         ;;
       a | arch)
-        if [[ "$value" = "$local_arch" ]]; then
-          (( negate )) && delta=-1 || delta=1
-        else
-          (( negate )) && delta=1
-        fi
+        [[ "$value" = "$local_arch" ]] && delta=1 || delta=-1
         ;;
       o | os)
-        if [[ "$value" = "$local_system" ]]; then
-          (( negate )) && delta=-1 || delta=2
-        else
-          (( negate )) && delta=2
-        fi
+        [[ "$value" = "$local_system" ]] && delta=2 || delta=-2
         ;;
       d | distro)
-        if [[ "${value// /_}" = "${local_distro// /_}" ]]; then
-          (( negate )) && delta=-1 || delta=4
-        else
-          (( negate )) && delta=4
-        fi
+        [[ "${value// /_}" = "${local_distro// /_}" ]] && delta=4 || delta=-4
         ;;
       f | distro_family)
-        if [[ "${value// /_}" = "${local_distro_family// /_}" ]]; then
-          (( negate )) && delta=-1 || delta=8
-        else
-          (( negate )) && delta=8
-        fi
+        [[ "${value// /_}" = "${local_distro_family// /_}" ]] && delta=8 || delta=-8
         ;;
       c | class)
-        if in_list "$value" "${local_classes[@]}"; then
-          (( negate )) && delta=-1 || delta=16
-        else
-          (( negate )) && delta=16
-        fi
+        in_list "$value" "${local_classes[@]}" && delta=16 || delta=-16
         ;;
       h | hostname)
-        if [[ "$value" = "$local_host" ]]; then
-          (( negate )) && delta=-1 || delta=32
-        else
-          (( negate )) && delta=32
-        fi
+        [[ "$value" = "$local_host" ]] && delta=32 || delta=-32
         ;;
       u | user)
-        if [[ "$value" = "$local_user" ]]; then
-          (( negate )) && delta=-1 || delta=64
-        else
-          (( negate )) && delta=64
-        fi
+        [[ "$value" = "$local_user" ]] && delta=64 || delta=-64
         ;;
       e | extension)
+        # extension isn't a condition and doesn't affect the score
         continue
         ;;
       t | template | yadm)
@@ -264,6 +237,7 @@ function score_file() {
     esac
     shopt -u nocasematch
 
+    (( negate )) && delta=$((-delta))
     if ((delta < 0)); then
       score=0
       return

--- a/yadm
+++ b/yadm
@@ -181,13 +181,13 @@ function score_file() {
 
     # Check for negative condition prefix (e.g., "~<label>")
     local negate=0
-    if [[ "$label" == ~* ]]; then
+    if [ "${label:0:1}" = "~" ]; then
       negate=1
       label="${label:1}"
     fi
 
     shopt -s nocasematch
-    local -i delta=-1
+    local -i delta=$(( negate ? 1 : -1 ))
     case "$label" in
       default)
         delta=0

--- a/yadm
+++ b/yadm
@@ -179,6 +179,13 @@ function score_file() {
     local value=${field#*.}
     [ "$field" = "$label" ] && value="" # when .value is omitted
 
+    # Check for negative condition prefix (e.g., "!<label>")
+    local negate=0
+    if [[ "$label" == !* ]]; then
+      negate=1
+      label="${label:1}"
+    fi
+
     shopt -s nocasematch
     local -i delta=-1
     case "$label" in
@@ -186,28 +193,55 @@ function score_file() {
         delta=0
         ;;
       a | arch)
-        [[ "$value" = "$local_arch" ]] && delta=1
+        if [[ "$value" = "$local_arch" ]]; then
+          (( negate )) && delta=-1 || delta=1
+        else
+          (( negate )) && delta=1
+        fi
         ;;
       o | os)
-        [[ "$value" = "$local_system" ]] && delta=2
+        if [[ "$value" = "$local_system" ]]; then
+          (( negate )) && delta=-1 || delta=2
+        else
+          (( negate )) && delta=2
+        fi
         ;;
       d | distro)
-        [[ "${value// /_}" = "${local_distro// /_}" ]] && delta=4
+        if [[ "${value// /_}" = "${local_distro// /_}" ]]; then
+          (( negate )) && delta=-1 || delta=4
+        else
+          (( negate )) && delta=4
+        fi
         ;;
       f | distro_family)
-        [[ "${value// /_}" = "${local_distro_family// /_}" ]] && delta=8
+        if [[ "${value// /_}" = "${local_distro_family// /_}" ]]; then
+          (( negate )) && delta=-1 || delta=8
+        else
+          (( negate )) && delta=8
+        fi
         ;;
       c | class)
-        in_list "$value" "${local_classes[@]}" && delta=16
+        if in_list "$value" "${local_classes[@]}"; then
+          (( negate )) && delta=-1 || delta=16
+        else
+          (( negate )) && delta=16
+        fi
         ;;
       h | hostname)
-        [[ "$value" = "$local_host" ]] && delta=32
+        if [[ "$value" = "$local_host" ]]; then
+          (( negate )) && delta=-1 || delta=32
+        else
+          (( negate )) && delta=32
+        fi
         ;;
       u | user)
-        [[ "$value" = "$local_user" ]] && delta=64
+        if [[ "$value" = "$local_user" ]]; then
+          (( negate )) && delta=-1 || delta=64
+        else
+          (( negate )) && delta=64
+        fi
         ;;
       e | extension)
-        # extension isn't a condition and doesn't affect the score
         continue
         ;;
       t | template | yadm)

--- a/yadm.1
+++ b/yadm.1
@@ -493,14 +493,12 @@ See the TEMPLATES section for more details.
 Valid if the value matches the current user.
 Current user is calculated by running
 .BR "id \-u \-n" .
-.BR [ weight\ = \ 64]
 .TP
 .BR hostname ,\  h
 Valid if the value matches the short hostname.
 Hostname is calculated by running
 .BR "uname \-n" ,
 and trimming off any domain.
-.BR [ weight\ = \ 32]
 .TP
 .BR class ,\  c
 Valid if the value matches the
@@ -510,7 +508,6 @@ Class must be manually set using
 .BR "yadm config local.class <class>" .
 See the CONFIGURATION section for more details about setting
 .BR local.class .
-.BR [ weight\ = \ 16]
 .TP
 .BR distro ,\  d
 Valid if the value matches the distro.
@@ -518,26 +515,22 @@ Distro is calculated by running
 .B "lsb_release \-si"
 or by inspecting the ID from
 .BR "/etc/os-release" .
-.BR [ weight\ = \ 8]
 .TP
 .BR distro_family ,\  f
 Valid if the value matches the distro family.
 Distro family is calculated by inspecting the ID_LIKE line from
 .B "/etc/os-release"
 (or ID if no ID_LIKE line is found).
-.BR [ weight\ = \ 4]
 .TP
 .BR os ,\  o
 Valid if the value matches the OS.
 OS is calculated by running
 .BR "uname \-s" .
-.BR [ weight\ = \ 2]
 .TP
 .BR arch ,\  a
 Valid if the value matches the architecture.
 Architecture is calculated by running
 .BR "uname \-m" .
-.BR [ weight\ = \ 1]
 .TP
 .B default
 Valid when no other alternate is valid.
@@ -614,55 +607,10 @@ Windows Subsystem for Linux, where the os is reported as WSL, the link will be:
 
 .IR $HOME/path/example.txt " -> " $HOME/path/example.txt##~os.Linux,~os.Darwin,~os.SunOS
 
-Negative conditions use the weight which corresponds to the attached attribute.
+Negative conditions use the same weight which corresponds to the attached attribute.
 
 If no "##default" version exists and no files have valid conditions, then no
 link will be created.
-
-Weighting for multiple valid alternatives is calculated using the weights specified
-above. For instance, on a Linux server named "host1" with class set to "Work", the
-alternatives will have the following weights:
-
-  - $HOME/path/example.txt##default
-  
-    Used if there are no other valid alternatives.
-
-  - $HOME/path/example.txt##class.Work
-  
-      1064 = (1000 + 64 (class)) * 1 (valid)
-
-  - $HOME/path/example.txt##os.Darwin
-  
-      0 = (1000 + 2 (os)) * 0 (invalid)
-
-  - $HOME/path/example.txt##os.Darwin,hostname.host1
-  
-      0 = (1000 + 2 (os) + 32 (hostname)) * 0 (invalid)
-
-  - $HOME/path/example.txt##os.Darwin,hostname.host2
-  
-      0 = (1000 + 2 (os) + 32 (hostname)) * 0 (invalid)
-
-  - $HOME/path/example.txt##os.Linux
-  
-      1002 = (1000 + 2 (os)) * 1 (valid)
-
-  - $HOME/path/example.txt##os.Linux,hostname.host1
-  
-      1034 = (1000 + 2 (os) + 32 (hostname)) * 1 (valid)
-
-  - $HOME/path/example.txt##os.Linux,hostname.host2
-  
-      1034 = (1000 + 2 (os) + 32 (hostname)) * 0 (invalid)
-
-  - $HOME/path/example.txt##~os.Linux,~os.Darwin,~os.SunOS
-
-      1006 = (1000 + 2 (~os) + 2 (~os) + 2 (~os)) * 0 (invalid)
-
-In this case, with a Linux server named "host1" with class set to "Work", the link will
-be:
-
-.IR $HOME/path/example.txt " -> " $HOME/path/example.txt##class.Work
 
 Links are also created for directories named this way, as long as they have at
 least one yadm managed file within them.

--- a/yadm.1
+++ b/yadm.1
@@ -489,16 +489,18 @@ These are the supported attributes, in the order of the weighted precedence:
 Valid when the value matches a supported template processor.
 See the TEMPLATES section for more details.
 .TP
-.BR user ,\  u
+.BR user ,\  u\ 
 Valid if the value matches the current user.
 Current user is calculated by running
 .BR "id \-u \-n" .
+.BR [ weight\ = \ 64]
 .TP
 .BR hostname ,\  h
 Valid if the value matches the short hostname.
 Hostname is calculated by running
 .BR "uname \-n" ,
 and trimming off any domain.
+.BR [ weight\ = \ 32]
 .TP
 .BR class ,\  c
 Valid if the value matches the
@@ -508,6 +510,7 @@ Class must be manually set using
 .BR "yadm config local.class <class>" .
 See the CONFIGURATION section for more details about setting
 .BR local.class .
+.BR [ weight\ = \ 16]
 .TP
 .BR distro ,\  d
 Valid if the value matches the distro.
@@ -515,22 +518,26 @@ Distro is calculated by running
 .B "lsb_release \-si"
 or by inspecting the ID from
 .BR "/etc/os-release" .
+.BR [ weight\ = \ 8]
 .TP
 .BR distro_family ,\  f
 Valid if the value matches the distro family.
 Distro family is calculated by inspecting the ID_LIKE line from
 .B "/etc/os-release"
 (or ID if no ID_LIKE line is found).
+.BR [ weight\ = \ 4]
 .TP
 .BR os ,\  o
 Valid if the value matches the OS.
 OS is calculated by running
 .BR "uname \-s" .
+.BR [ weight\ = \ 2]
 .TP
 .BR arch ,\  a
 Valid if the value matches the architecture.
 Architecture is calculated by running
 .BR "uname \-m" .
+.BR [ weight\ = \ 1]
 .TP
 .B default
 Valid when no other alternate is valid.
@@ -575,6 +582,7 @@ files are managed by yadm's repository:
   - $HOME/path/example.txt##os.Linux
   - $HOME/path/example.txt##os.Linux,hostname.host1
   - $HOME/path/example.txt##os.Linux,hostname.host2
+  - $HOME/path/example.txt##~os.Linux,~os.Darwin,~os.SunOS
 
 If running on a Macbook named "host2",
 yadm will create a symbolic link which looks like this:
@@ -601,8 +609,60 @@ If running on a system, with class set to "Work", the link will be:
 
 .IR $HOME/path/example.txt " -> " $HOME/path/example.txt##class.Work
 
+Negative conditions are supported via the "~" prefix. If running within 
+Windows Subsystem for Linux, where the os is reported as WSL, the link will be:
+
+.IR $HOME/path/example.txt " -> " $HOME/path/example.txt##~os.Linux,~os.Darwin,~os.SunOS
+
+Negative conditions use the weight which corresponds to the attached attribute.
+
 If no "##default" version exists and no files have valid conditions, then no
 link will be created.
+
+Weighting for multiple valid alternatives is calculated using the weights specified
+above. For instance, on a Linux server named "host1" with class set to "Work", the
+alternatives will have the following weights:
+
+  - $HOME/path/example.txt##default
+  
+    Used if there are no other valid alternatives.
+
+  - $HOME/path/example.txt##class.Work
+  
+      1064 = (1000 + 64 (class)) * 1 (valid)
+
+  - $HOME/path/example.txt##os.Darwin
+  
+      0 = (1000 + 2 (os)) * 0 (invalid)
+
+  - $HOME/path/example.txt##os.Darwin,hostname.host1
+  
+      0 = (1000 + 2 (os) + 32 (hostname)) * 0 (invalid)
+
+  - $HOME/path/example.txt##os.Darwin,hostname.host2
+  
+      0 = (1000 + 2 (os) + 32 (hostname)) * 0 (invalid)
+
+  - $HOME/path/example.txt##os.Linux
+  
+      1002 = (1000 + 2 (os)) * 1 (valid)
+
+  - $HOME/path/example.txt##os.Linux,hostname.host1
+  
+      1034 = (1000 + 2 (os) + 32 (hostname)) * 1 (valid)
+
+  - $HOME/path/example.txt##os.Linux,hostname.host2
+  
+      1034 = (1000 + 2 (os) + 32 (hostname)) * 0 (invalid)
+
+  - $HOME/path/example.txt##~os.Linux,~os.Darwin,~os.SunOS
+
+      1006 = (1000 + 2 (~os) + 2 (~os) + 2 (~os)) * 0 (invalid)
+
+In this case, with a Linux server named "host1" with class set to "Work", the link will
+be:
+
+.IR $HOME/path/example.txt " -> " $HOME/path/example.txt##class.Work
 
 Links are also created for directories named this way, as long as they have at
 least one yadm managed file within them.

--- a/yadm.1
+++ b/yadm.1
@@ -489,7 +489,7 @@ These are the supported attributes, in the order of the weighted precedence:
 Valid when the value matches a supported template processor.
 See the TEMPLATES section for more details.
 .TP
-.BR user ,\  u\ 
+.BR user ,\  u
 Valid if the value matches the current user.
 Current user is calculated by running
 .BR "id \-u \-n" .

--- a/yadm.1
+++ b/yadm.1
@@ -475,9 +475,11 @@ commas.
 
 Each condition is an attribute/value pair, separated by a period. Some
 conditions do not require a "value", and in that case, the period and value can
-be omitted. Most attributes can be abbreviated as a single letter.
+be omitted. Most attributes can be abbreviated as a single letter. Prefixing an
+attribute with "~" negates the condition, meaning the condition is considered 
+only if the attribute/value pair evaluates to false.
 
-  <attribute>[.<value>]
+  [~]<attribute>[.<value>]
 
 .BR NOTE :
 Value is compared case-insensitive.
@@ -552,11 +554,12 @@ For all files managed by yadm's repository or listed in
 if they match this naming convention,
 symbolic links will be created for the most appropriate version.
 
-The "most appropriate" version is determined by calculating a score for each
-version of a file. A template is always scored higher than any symlink
-condition. The number of conditions is the next largest factor in scoring.
-Files with more conditions will always be favored. Any invalid condition will
-disqualify that file completely.
+The "most appropriate" version is determined by calculating a score for each 
+version of a file. A template is always scored higher than any symlink 
+condition. The number of conditions is the next largest factor in scoring; 
+files with more conditions will always be favored. Negative conditions (prefixed 
+with "~") are scored only relative to the number of non-negated conditions.
+Any invalid condition will disqualify that file completely.
 
 If you don't care to have all versions of alternates stored in the same
 directory as the generated symlink, you can place them in the
@@ -575,7 +578,7 @@ files are managed by yadm's repository:
   - $HOME/path/example.txt##os.Linux
   - $HOME/path/example.txt##os.Linux,hostname.host1
   - $HOME/path/example.txt##os.Linux,hostname.host2
-  - $HOME/path/example.txt##~os.Linux,~os.Darwin,~os.SunOS
+  - $HOME/path/example.txt##class.Work,~os.Darwin
 
 If running on a Macbook named "host2",
 yadm will create a symbolic link which looks like this:
@@ -598,14 +601,15 @@ If running on a Solaris server, the link will use the default version:
 
 .IR $HOME/path/example.txt " -> " $HOME/path/example.txt##default
 
-If running on a system, with class set to "Work", the link will be:
+If running on a Macbook with class set to "Work", the link will be:
 
 .IR $HOME/path/example.txt " -> " $HOME/path/example.txt##class.Work
 
-Negative conditions are supported via the "~" prefix. If running within 
-Windows Subsystem for Linux, where the os is reported as WSL, the link will be:
+Negative conditions are supported via the "~" prefix. If again running on a system
+with class set to "Work", but instead within Windows Subsystem for Linux, where the 
+os is reported as WSL, the link will be:
 
-.IR $HOME/path/example.txt " -> " $HOME/path/example.txt##~os.Linux,~os.Darwin,~os.SunOS
+.IR $HOME/path/example.txt " -> " $HOME/path/example.txt##class.Work,~os.Darwin
 
 Negative conditions use the same weight which corresponds to the attached attribute.
 


### PR DESCRIPTION
### What does this PR do?

Adds negative conditions to alt resolution. For instance, if `local.class=test`, `file##!c.test` is an invalid condition. This is useful for me where I want to disable a file on a specific computer.

### What issues does this PR fix or reference?

I didn't make an issue, should I?

### Previous Behavior

This is a new feature. Before, there was no way (that I know) to accomplish a _negative_ condition.

### New Behavior

See test case and comments below. Basically, it's possible to avoid using a specific file if a given condition is met if prefixed with `!`.

```bash
YADM_TEST=1 source {yadm}
score=0
local_class="testclass"
local_classes=("testclass")
# Negative condition with matching value should yield delta -1 and zero the score.
score_file "filename##!class.testclass" "dest"
echo "score: $score"
# Negative condition with non-matching value should yield delta 16.
score=0
score_file "filename##!class.badclass" "dest"
echo "score2: $score"
```

### Have [tests][1] been written for this change?

Yes

### Have these commits been [signed with GnuPG][2]?

No

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/yadm-dev/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/yadm-dev/yadm/blob/master/.github/CONTRIBUTING.md
